### PR TITLE
Make messaging system use default Eclipse console color for INFO messages

### DIFF
--- a/commons-eclipse/fr.inria.diverse.commons.eclipse.messagingsystem.ui/src/main/java/fr/inria/diverse/commons/eclipse/messagingsystem/ui/internal/console/EclipseConsoleIO.java
+++ b/commons-eclipse/fr.inria.diverse.commons.eclipse.messagingsystem.ui/src/main/java/fr/inria/diverse/commons/eclipse/messagingsystem/ui/internal/console/EclipseConsoleIO.java
@@ -189,7 +189,7 @@ public class EclipseConsoleIO extends ConsoleIO implements IPropertyChangeListen
 	 */
 	public void changeColor(Color c){
 		Color previousColor = ((IOConsoleOutputStream) getOutputStream()).getColor();
-		if(!c.equals(previousColor)){
+		if( (c==null && c!= previousColor) || (c!=null && !c.equals(previousColor)) ){
 			// need to change to another stream for the new color
 			changeStream(); // reset the stream
 			((IOConsoleOutputStream) getOutputStream()).setColor(c);

--- a/commons-eclipse/fr.inria.diverse.commons.eclipse.messagingsystem.ui/src/main/java/fr/inria/diverse/commons/eclipse/messagingsystem/ui/internal/console/message/ConsoleMessage.java
+++ b/commons-eclipse/fr.inria.diverse.commons.eclipse.messagingsystem.ui/src/main/java/fr/inria/diverse/commons/eclipse/messagingsystem/ui/internal/console/message/ConsoleMessage.java
@@ -16,7 +16,7 @@ import org.eclipse.swt.graphics.Color;
 public class ConsoleMessage {
 
 	// some default colors that can be used
-	public static final Color INFO = new Color(null, 0,0,0);
+	public static final Color INFO = null; // make eclipse use default console text color  
 	public static final Color DEBUG = new Color(null, 0,128,0);
 	public static final Color DEBUG_WARNING = new Color(null, 128,128,0);
 	public static final Color DEBUG_ERROR = new Color(null, 128,64,0);


### PR DESCRIPTION
I am now using a dark theme for Eclipse, which means that the background of my consoles is dark grey. However, the diverse messaging system uses black to display INFO messages, which means it's not very readable (see screenshot below).

While this doesn't solve the problem for other types of messages which may not be readable on dark gray as well, I propose to use the default Eclipse console text color when displaying INFO messages. This ensures that it is always readable, since the default value is based on the current and consistent color palette.

I have looked into the Eclipse API, and this can be simply achieved by using a `null` color when using an `IOConsoleOutputStream`. This patch simply makes use of that.

Before (see the one line of black text at the bottom):
![capture d ecran de 2016-05-10 09-58-15](https://cloud.githubusercontent.com/assets/5868014/15139723/f81fce88-1697-11e6-8169-0d00ce9ce71f.png)

After the patch (see the one line of white text at the bottom):
![capture d ecran de 2016-05-10 09-57-51](https://cloud.githubusercontent.com/assets/5868014/15139724/faf0d968-1697-11e6-83e8-8e48011e49fa.png)
